### PR TITLE
Post API 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     id("org.springframework.boot") version "3.4.4"
     id("io.spring.dependency-management") version "1.1.7"
     kotlin("plugin.jpa") version "1.9.25"
+    kotlin("plugin.serialization") version "1.9.25"
 }
 
 group = "org.grew"
@@ -27,6 +28,9 @@ dependencies {
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.springframework.boot:spring-boot-starter-security")
+
+    // json
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.1")
 
     // db for dev
     implementation("org.xerial:sqlite-jdbc")

--- a/src/main/kotlin/org/grew/grewwebsiteserver/common/Response.kt
+++ b/src/main/kotlin/org/grew/grewwebsiteserver/common/Response.kt
@@ -16,7 +16,7 @@ class Response {
         // statusCode: 200
         fun <T> success(data: T): ResponseEntity<Body<T>> {
             val body = Body(result = "SUCCESS", data = data, errorCode = null, errorMessage = null)
-            return ResponseEntity.ok(body)
+            return ResponseEntity.status(200).body(body)
         }
 
         // statusCode: 400

--- a/src/main/kotlin/org/grew/grewwebsiteserver/common/Response.kt
+++ b/src/main/kotlin/org/grew/grewwebsiteserver/common/Response.kt
@@ -1,0 +1,37 @@
+package org.grew.grewwebsiteserver.common
+
+import org.springframework.http.ResponseEntity
+
+class Response {
+
+    data class Body<T>(
+        val result: String, // 성공인지, 실패인지 (SUCCESS, FAILURE)
+        val data: T?, // 성공일 때 전달되는 결과
+        val errorCode: String?, // 실패일 때 전달되는 Code
+        val errorMessage: String? // 실패일 때 전달되는 메세지
+    )
+
+    companion object {
+
+        // statusCode: 200
+        fun <T> success(data: T): ResponseEntity<Body<T>> {
+            val body = Body(result = "SUCCESS", data = data, errorCode = null, errorMessage = null)
+            return ResponseEntity.ok(body)
+        }
+
+        // statusCode: 400
+        // errorCode는 클라이언트에게 오류 케이스를 알려줘야 할 필요가 있을 때 사용
+        fun <T> failure(errorCode: String = "NOT_DEFINED", errorMessage: String?): ResponseEntity<Body<T>> {
+            val body = Body<T>(result = "FAILURE", data = null, errorCode = errorCode, errorMessage = errorMessage)
+            return ResponseEntity.status(400).body(body)
+        }
+
+        // statusCode: 500
+        fun <T> unexpectedException(e: Exception): ResponseEntity<Body<T>> {
+            val body = Body<T>(result = "FAILURE", data = null, errorCode = "UNEXPECTED_EXCEPTION", errorMessage = e.message)
+            return ResponseEntity.status(500).body(body)
+        }
+    }
+}
+
+typealias ResponseDto<T> = ResponseEntity<Response.Body<T>>

--- a/src/main/kotlin/org/grew/grewwebsiteserver/domain/post/PostController.kt
+++ b/src/main/kotlin/org/grew/grewwebsiteserver/domain/post/PostController.kt
@@ -1,14 +1,10 @@
 package org.grew.grewwebsiteserver.domain.post
 
-import org.grew.grewwebsiteserver.common.Res
 import org.grew.grewwebsiteserver.common.Response
-import org.grew.grewwebsiteserver.common.ResponseBody
 import org.grew.grewwebsiteserver.common.ResponseDto
-import org.grew.grewwebsiteserver.domain.auth.kakao.ApiResponse
 import org.grew.grewwebsiteserver.domain.post.dto.PostCreateRequestDto
 import org.grew.grewwebsiteserver.domain.post.dto.PostResponseDto
 import org.grew.grewwebsiteserver.domain.post.dto.PostUpdateRequestDto
-import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import java.lang.IllegalArgumentException
 

--- a/src/main/kotlin/org/grew/grewwebsiteserver/domain/post/PostController.kt
+++ b/src/main/kotlin/org/grew/grewwebsiteserver/domain/post/PostController.kt
@@ -5,13 +5,7 @@ import org.grew.grewwebsiteserver.domain.post.dto.PostCreateRequestDto
 import org.grew.grewwebsiteserver.domain.post.dto.PostResponseDto
 import org.grew.grewwebsiteserver.domain.post.dto.PostUpdateRequestDto
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PatchMapping
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/api/posts")
@@ -48,6 +42,16 @@ class PostController(
             ResponseEntity.ok(ApiResponse.success(data))
         } catch (e: Exception) {
             ResponseEntity.ok(ApiResponse.failure("게시물 업데이트 중 오류가 발생했습니다. ${e.message}"))
+        }
+    }
+
+    @DeleteMapping("/{id}")
+    fun deletePost(@PathVariable id: Long): ResponseEntity<ApiResponse<Long>> {
+        return try {
+            postService.deletePost(postId = id)
+            ResponseEntity.ok(ApiResponse.success(id))
+        } catch (e: Exception) {
+            ResponseEntity.ok(ApiResponse.failure("게시물 삭제 중 오류가 발생했습니다. ${e.message}"))
         }
     }
 }

--- a/src/main/kotlin/org/grew/grewwebsiteserver/domain/post/PostController.kt
+++ b/src/main/kotlin/org/grew/grewwebsiteserver/domain/post/PostController.kt
@@ -1,11 +1,16 @@
 package org.grew.grewwebsiteserver.domain.post
 
+import org.grew.grewwebsiteserver.common.Res
+import org.grew.grewwebsiteserver.common.Response
+import org.grew.grewwebsiteserver.common.ResponseBody
+import org.grew.grewwebsiteserver.common.ResponseDto
 import org.grew.grewwebsiteserver.domain.auth.kakao.ApiResponse
 import org.grew.grewwebsiteserver.domain.post.dto.PostCreateRequestDto
 import org.grew.grewwebsiteserver.domain.post.dto.PostResponseDto
 import org.grew.grewwebsiteserver.domain.post.dto.PostUpdateRequestDto
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
+import java.lang.IllegalArgumentException
 
 @RestController
 @RequestMapping("/api/posts")
@@ -14,44 +19,56 @@ class PostController(
 ) {
 
     @GetMapping("/{id}")
-    fun getPost(@PathVariable id: Long): ResponseEntity<ApiResponse<PostResponseDto>> {
-        val data = postService.getPostByPostId(postId = id) ?: return ResponseEntity.ok(ApiResponse.failure("id에 해당하는 게시물이 없습니다."))
-        return ResponseEntity.ok(ApiResponse.success(data))
+    fun getPost(@PathVariable id: Long): ResponseDto<PostResponseDto> {
+        return try {
+            val data = postService.getPostByPostId(postId = id)
+            Response.success(data)
+        } catch (e: IllegalArgumentException) {
+            Response.failure(errorMessage = e.message)
+        } catch (e: Exception) {
+            Response.unexpectedException(e)
+        }
     }
 
     @GetMapping
-    fun getPosts(): ResponseEntity<ApiResponse<List<PostResponseDto>>> {
-        val data = postService.getPosts()
-        return ResponseEntity.ok(ApiResponse.success(data))
+    fun getPosts(): ResponseDto<List<PostResponseDto>> {
+        return try {
+            val data = postService.getPosts()
+            Response.success(data)
+        }  catch (e: Exception) {
+            Response.unexpectedException(e)
+        }
     }
 
     @PostMapping
-    fun createPost(@RequestBody request: PostCreateRequestDto): ResponseEntity<ApiResponse<PostResponseDto>> {
+    fun createPost(@RequestBody request: PostCreateRequestDto): ResponseDto<PostResponseDto> {
         return try {
             val data = postService.createPost(request = request)
-            ResponseEntity.ok(ApiResponse.success(data))
+            Response.success(data)
         } catch (e: Exception) {
-            ResponseEntity.ok(ApiResponse.failure("게시물 생성 중 오류가 발생했습니다. ${e.message}"))
+            Response.unexpectedException(e)
         }
     }
 
     @PatchMapping("/{id}")
-    fun updatePost(@PathVariable id: Long, @RequestBody request: PostUpdateRequestDto): ResponseEntity<ApiResponse<PostResponseDto>> {
+    fun updatePost(@PathVariable id: Long, @RequestBody request: PostUpdateRequestDto): ResponseDto<PostResponseDto> {
         return try {
             val data = postService.updatePost(postId = id, request = request)
-            ResponseEntity.ok(ApiResponse.success(data))
+            Response.success(data)
+        } catch (e: IllegalArgumentException) {
+            Response.failure(errorMessage = e.message)
         } catch (e: Exception) {
-            ResponseEntity.ok(ApiResponse.failure("게시물 업데이트 중 오류가 발생했습니다. ${e.message}"))
+            Response.unexpectedException(e)
         }
     }
 
     @DeleteMapping("/{id}")
-    fun deletePost(@PathVariable id: Long): ResponseEntity<ApiResponse<Long>> {
+    fun deletePost(@PathVariable id: Long): ResponseDto<Long> {
         return try {
             postService.deletePost(postId = id)
-            ResponseEntity.ok(ApiResponse.success(id))
+            Response.success(id)
         } catch (e: Exception) {
-            ResponseEntity.ok(ApiResponse.failure("게시물 삭제 중 오류가 발생했습니다. ${e.message}"))
+            Response.unexpectedException(e)
         }
     }
 }

--- a/src/main/kotlin/org/grew/grewwebsiteserver/domain/post/PostController.kt
+++ b/src/main/kotlin/org/grew/grewwebsiteserver/domain/post/PostController.kt
@@ -1,0 +1,53 @@
+package org.grew.grewwebsiteserver.domain.post
+
+import org.grew.grewwebsiteserver.domain.auth.kakao.ApiResponse
+import org.grew.grewwebsiteserver.domain.post.dto.PostCreateRequestDto
+import org.grew.grewwebsiteserver.domain.post.dto.PostResponseDto
+import org.grew.grewwebsiteserver.domain.post.dto.PostUpdateRequestDto
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/posts")
+class PostController(
+    private val postService: PostService
+) {
+
+    @GetMapping("/{id}")
+    fun getPost(@PathVariable id: Long): ResponseEntity<ApiResponse<PostResponseDto>> {
+        val data = postService.getPostByPostId(postId = id) ?: return ResponseEntity.ok(ApiResponse.failure("id에 해당하는 게시물이 없습니다."))
+        return ResponseEntity.ok(ApiResponse.success(data))
+    }
+
+    @GetMapping
+    fun getPosts(): ResponseEntity<ApiResponse<List<PostResponseDto>>> {
+        val data = postService.getPosts()
+        return ResponseEntity.ok(ApiResponse.success(data))
+    }
+
+    @PostMapping
+    fun createPost(@RequestBody request: PostCreateRequestDto): ResponseEntity<ApiResponse<PostResponseDto>> {
+        return try {
+            val data = postService.createPost(request = request)
+            ResponseEntity.ok(ApiResponse.success(data))
+        } catch (e: Exception) {
+            ResponseEntity.ok(ApiResponse.failure("게시물 생성 중 오류가 발생했습니다. ${e.message}"))
+        }
+    }
+
+    @PatchMapping("/{id}")
+    fun updatePost(@PathVariable id: Long, @RequestBody request: PostUpdateRequestDto): ResponseEntity<ApiResponse<PostResponseDto>> {
+        return try {
+            val data = postService.updatePost(postId = id, request = request)
+            ResponseEntity.ok(ApiResponse.success(data))
+        } catch (e: Exception) {
+            ResponseEntity.ok(ApiResponse.failure("게시물 업데이트 중 오류가 발생했습니다. ${e.message}"))
+        }
+    }
+}

--- a/src/main/kotlin/org/grew/grewwebsiteserver/domain/post/PostRepository.kt
+++ b/src/main/kotlin/org/grew/grewwebsiteserver/domain/post/PostRepository.kt
@@ -5,5 +5,4 @@ import org.springframework.data.repository.CrudRepository
 
 interface PostRepository: CrudRepository<Post, Long> {
 
-    fun findByPostId(postId: Long): Post?
 }

--- a/src/main/kotlin/org/grew/grewwebsiteserver/domain/post/PostRepository.kt
+++ b/src/main/kotlin/org/grew/grewwebsiteserver/domain/post/PostRepository.kt
@@ -1,0 +1,9 @@
+package org.grew.grewwebsiteserver.domain.post
+
+import org.grew.grewwebsiteserver.domain.post.entity.Post
+import org.springframework.data.repository.CrudRepository
+
+interface PostRepository: CrudRepository<Post, Long> {
+
+    fun findByPostId(postId: Long): Post?
+}

--- a/src/main/kotlin/org/grew/grewwebsiteserver/domain/post/PostService.kt
+++ b/src/main/kotlin/org/grew/grewwebsiteserver/domain/post/PostService.kt
@@ -1,0 +1,41 @@
+package org.grew.grewwebsiteserver.domain.post
+
+import org.grew.grewwebsiteserver.domain.post.dto.PostCreateRequestDto
+import org.grew.grewwebsiteserver.domain.post.dto.PostResponseDto
+import org.grew.grewwebsiteserver.domain.post.dto.PostUpdateRequestDto
+import org.grew.grewwebsiteserver.domain.post.entity.Post
+import org.springframework.stereotype.Service
+
+@Service
+class PostService(
+    private val postRepository: PostRepository
+) {
+    fun getPosts(): List<PostResponseDto> {
+        return postRepository.findAll().toList().map { PostResponseDto.from(entity = it) }
+    }
+
+    fun getPostByPostId(postId: Long): PostResponseDto? {
+        val entity = postRepository.findByPostId(postId) ?: return null
+        return PostResponseDto.from(entity = entity)
+    }
+
+    fun createPost(request: PostCreateRequestDto): PostResponseDto {
+        val entity = Post(
+            userId = null,
+            title = request.title,
+            contents = request.contents.map { it.toJsonString() }
+        )
+        postRepository.save(entity)
+        return PostResponseDto.from(entity = entity)
+    }
+
+    fun updatePost(postId: Long, request: PostUpdateRequestDto): PostResponseDto {
+        val entity = postRepository.findByPostId(postId) ?: throw IllegalArgumentException("id에 해당하는 게시물이 없습니다.")
+        entity.update(title = request.title, contents = request.contents.map { it.toJsonString() })
+        return PostResponseDto.from(entity = entity)
+    }
+
+    fun deletePost(postId: Long) {
+        postRepository.deleteById(postId)
+    }
+}

--- a/src/main/kotlin/org/grew/grewwebsiteserver/domain/post/PostService.kt
+++ b/src/main/kotlin/org/grew/grewwebsiteserver/domain/post/PostService.kt
@@ -5,6 +5,7 @@ import org.grew.grewwebsiteserver.domain.post.dto.PostResponseDto
 import org.grew.grewwebsiteserver.domain.post.dto.PostUpdateRequestDto
 import org.grew.grewwebsiteserver.domain.post.entity.Post
 import org.springframework.stereotype.Service
+import kotlin.jvm.optionals.getOrNull
 
 @Service
 class PostService(
@@ -14,8 +15,9 @@ class PostService(
         return postRepository.findAll().toList().map { PostResponseDto.from(entity = it) }
     }
 
-    fun getPostByPostId(postId: Long): PostResponseDto? {
-        val entity = postRepository.findByPostId(postId) ?: return null
+    fun getPostByPostId(postId: Long): PostResponseDto {
+        val entity = postRepository.findById(postId).getOrNull()
+            ?: throw IllegalArgumentException("id에 해당하는 게시물이 없습니다.")
         return PostResponseDto.from(entity = entity)
     }
 
@@ -30,8 +32,12 @@ class PostService(
     }
 
     fun updatePost(postId: Long, request: PostUpdateRequestDto): PostResponseDto {
-        val entity = postRepository.findByPostId(postId) ?: throw IllegalArgumentException("id에 해당하는 게시물이 없습니다.")
-        entity.update(title = request.title, contents = request.contents.map { it.toJsonString() })
+        val entity = postRepository.findById(postId).getOrNull()
+            ?: throw IllegalArgumentException("id에 해당하는 게시물이 없습니다.")
+        entity.update(
+            title = request.title,
+            contents = request.contents.map { it.toJsonString() }
+        )
         return PostResponseDto.from(entity = entity)
     }
 

--- a/src/main/kotlin/org/grew/grewwebsiteserver/domain/post/dto/PostContentDto.kt
+++ b/src/main/kotlin/org/grew/grewwebsiteserver/domain/post/dto/PostContentDto.kt
@@ -1,0 +1,47 @@
+package org.grew.grewwebsiteserver.domain.post.dto
+
+import com.fasterxml.jackson.annotation.JsonSubTypes
+import com.fasterxml.jackson.annotation.JsonTypeInfo
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    include = JsonTypeInfo.As.PROPERTY,
+    property = "type"
+)
+@JsonSubTypes(
+    JsonSubTypes.Type(value = PostContentDto.Text::class, name = "text"),
+    JsonSubTypes.Type(value = PostContentDto.Image::class, name = "image")
+)
+@Serializable
+sealed class PostContentDto {
+
+    @Serializable
+    @SerialName("text")
+    data class Text(
+        val text: String
+    ): PostContentDto()
+
+    @Serializable
+    @SerialName("image")
+    data class Image(
+        val imageUrl: String,
+        val mediaType: String
+    ): PostContentDto()
+
+    fun toJsonString(): String {
+        return json.encodeToString(this)
+    }
+
+    companion object {
+
+        val json = Json { classDiscriminator = "type" }
+
+        fun from(jsonString: String): PostContentDto {
+            return json.decodeFromString<PostContentDto>(jsonString)
+        }
+    }
+}

--- a/src/main/kotlin/org/grew/grewwebsiteserver/domain/post/dto/PostCreateRequestDto.kt
+++ b/src/main/kotlin/org/grew/grewwebsiteserver/domain/post/dto/PostCreateRequestDto.kt
@@ -1,0 +1,6 @@
+package org.grew.grewwebsiteserver.domain.post.dto
+
+data class PostCreateRequestDto(
+    val title: String,
+    val contents: List<PostContentDto>
+)

--- a/src/main/kotlin/org/grew/grewwebsiteserver/domain/post/dto/PostResponseDto.kt
+++ b/src/main/kotlin/org/grew/grewwebsiteserver/domain/post/dto/PostResponseDto.kt
@@ -1,0 +1,23 @@
+package org.grew.grewwebsiteserver.domain.post.dto
+
+import org.grew.grewwebsiteserver.domain.post.entity.Post
+import java.time.LocalDateTime
+
+data class PostResponseDto(
+    val postId: Long,
+    val title: String,
+    val contents: List<PostContentDto>,
+    val updatedAt: LocalDateTime
+) {
+
+    companion object {
+        fun from(entity: Post): PostResponseDto {
+            return PostResponseDto(
+                postId = entity.postId,
+                title = entity.title,
+                contents = entity.contents.map { PostContentDto.from(jsonString = it) },
+                updatedAt = entity.updatedAt
+            )
+        }
+    }
+}

--- a/src/main/kotlin/org/grew/grewwebsiteserver/domain/post/dto/PostUpdateRequestDto.kt
+++ b/src/main/kotlin/org/grew/grewwebsiteserver/domain/post/dto/PostUpdateRequestDto.kt
@@ -1,0 +1,7 @@
+package org.grew.grewwebsiteserver.domain.post.dto
+
+data class PostUpdateRequestDto(
+    val title: String,
+    val contents: List<PostContentDto>
+)
+

--- a/src/main/kotlin/org/grew/grewwebsiteserver/domain/post/entity/Post.kt
+++ b/src/main/kotlin/org/grew/grewwebsiteserver/domain/post/entity/Post.kt
@@ -1,0 +1,36 @@
+package org.grew.grewwebsiteserver.domain.post.entity
+
+import jakarta.persistence.*
+import org.springframework.data.annotation.CreatedDate
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "posts")
+data class Post(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val postId: Long = 0,
+
+    @Column(nullable = true, unique = false)
+    val userId: Long?,
+
+    @Column(nullable = false, unique = false)
+    var title: String,
+
+    // 저장되는 값은 jsonString
+    @Column(nullable = false, unique = false)
+    var contents: List<String>,
+
+    @Column(name = "created_at", updatable = false)
+    val createdAt: LocalDateTime = LocalDateTime.now(),
+
+    @Column(name = "updated_at")
+    var updatedAt: LocalDateTime = LocalDateTime.now()
+) {
+
+    fun update(title: String, contents: List<String>) {
+        this.title = title
+        this.contents = contents
+        this.updatedAt = LocalDateTime.now()
+    }
+}


### PR DESCRIPTION
## 🔥작업 내용

- 게시물 생성, 조회, 업데이트 기능을 추가합니다.
  - `GET` `api/posts/{id}` 단건 조회
  - `GET` `api/posts` 다건 조회
  - `POST` `api/posts` 생성
  - `PATCH` `api/posts/{id}` 업데이트
- 로그인 없이 게시물 CRUD를 다 가능하도록 구현했습니다.

## 📋참고 사항

sealed class를 이용하여 content에 들어가는 json object를 mapping 합니다.

```kotlin
data class Text(
  val text: String
): PostContentDto()

data class Image(
  val imageUrl: String,
  val mediaType: String
): PostContentDto()
```

+ 스웨거 쓰는 방법 알려주세요 ㅎㅎ
