### PR TITLE
파일 업로드를 위한 S3 Presigned URL 발급 API 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,6 +51,9 @@ dependencies {
     runtimeOnly("io.jsonwebtoken:jjwt-impl:0.11.5")
     runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.11.5") // Jackson을 사용할 경우
 
+    // s3
+    implementation("software.amazon.awssdk:s3:2.31.41")
+
     // test
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("io.kotest:kotest-runner-junit5:5.6.2")

--- a/src/main/kotlin/org/grew/grewwebsiteserver/config/S3Config.kt
+++ b/src/main/kotlin/org/grew/grewwebsiteserver/config/S3Config.kt
@@ -1,0 +1,39 @@
+package org.grew.grewwebsiteserver.config
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.presigner.S3Presigner
+
+@Configuration
+class S3Config(
+    @Value("\${cloud.aws.credentials.access-key}")
+    private val accessKey: String,
+    @Value("\${cloud.aws.credentials.secret-key}")
+    private val secretKey: String,
+    @Value("\${cloud.aws.region.static}")
+    private val regionName: String
+) {
+
+    @Bean
+    fun s3Client(): S3Client {
+        val credentials = AwsBasicCredentials.create(accessKey, secretKey)
+        return S3Client.builder()
+            .region(Region.of(regionName))
+            .credentialsProvider(StaticCredentialsProvider.create(credentials))
+            .build()
+    }
+
+    @Bean
+    fun s3Presigner(): S3Presigner {
+        val credentials = AwsBasicCredentials.create(accessKey, secretKey)
+        return S3Presigner.builder()
+            .region(Region.of(regionName))
+            .credentialsProvider(StaticCredentialsProvider.create(credentials))
+            .build()
+    }
+}

--- a/src/main/kotlin/org/grew/grewwebsiteserver/domain/post/dto/PostContentDto.kt
+++ b/src/main/kotlin/org/grew/grewwebsiteserver/domain/post/dto/PostContentDto.kt
@@ -29,7 +29,7 @@ sealed class PostContentDto {
     @SerialName("image")
     data class Image(
         val imageUrl: String,
-        val mediaType: String
+        val contentType: String
     ): PostContentDto()
 
     fun toJsonString(): String {

--- a/src/main/kotlin/org/grew/grewwebsiteserver/domain/resource/ResourceController.kt
+++ b/src/main/kotlin/org/grew/grewwebsiteserver/domain/resource/ResourceController.kt
@@ -1,0 +1,27 @@
+package org.grew.grewwebsiteserver.domain.resource
+
+import org.grew.grewwebsiteserver.common.Response
+import org.grew.grewwebsiteserver.common.ResponseDto
+import org.grew.grewwebsiteserver.domain.resource.dto.ResourceUploadUrlDto
+import org.grew.grewwebsiteserver.domain.resource.dto.ResourceUploadUrlRequestDto
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/resource")
+class ResourceController(
+    private val resourceService: ResourceService
+) {
+
+    @PostMapping("/uploadUrl")
+    fun generateUploadUrl(@RequestBody request: ResourceUploadUrlRequestDto): ResponseDto<ResourceUploadUrlDto> {
+        return try {
+            val data = resourceService.generateUploadUrl(request = request)
+            Response.success(data)
+        } catch (e: Exception) {
+            Response.unexpectedException(e)
+        }
+    }
+}

--- a/src/main/kotlin/org/grew/grewwebsiteserver/domain/resource/ResourceService.kt
+++ b/src/main/kotlin/org/grew/grewwebsiteserver/domain/resource/ResourceService.kt
@@ -1,0 +1,51 @@
+package org.grew.grewwebsiteserver.domain.resource
+
+import org.grew.grewwebsiteserver.domain.resource.dto.ResourceUploadUrlDto
+import org.grew.grewwebsiteserver.domain.resource.dto.ResourceUploadUrlRequestDto
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+import software.amazon.awssdk.services.s3.model.PutObjectRequest
+import software.amazon.awssdk.services.s3.presigner.S3Presigner
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest
+import java.util.*
+
+@Service
+class ResourceService(
+    private val s3Presigner: S3Presigner,
+    @Value("\${cloud.aws.region.static}")
+    private val regionName: String,
+    @Value("\${cloud.aws.s3.bucket}")
+    private val bucketName: String
+) {
+
+    fun generateUploadUrl(request: ResourceUploadUrlRequestDto): ResourceUploadUrlDto {
+        // 파일이름이 고유한 키가 되어 저장되기 때문에, unique한 파일명을 만듭니다.
+        val randomFileName = "${UUID.randomUUID()}_${request.fileName}"
+
+        return ResourceUploadUrlDto(
+            fileName = randomFileName,
+            contentType = request.contentType,
+            uploadUrl = generatePresignedUrl(fileName = randomFileName),
+            downloadUrl = generateDownloadUrl(fileName = randomFileName)
+        )
+    }
+
+    private fun generatePresignedUrl(fileName: String): String {
+        val objectRequest = PutObjectRequest.builder()
+            .bucket(bucketName)
+            .key(fileName)
+            .build()
+
+        val presignRequest = PutObjectPresignRequest.builder()
+            .putObjectRequest(objectRequest)
+            .signatureDuration(java.time.Duration.ofHours(1))
+            .build()
+
+        return s3Presigner.presignPutObject(presignRequest).url().toString()
+    }
+
+    // S3 버킷 리소스에 public 접근이 가능하기에, download url은 따로 Presigned가 필요없음
+    private fun generateDownloadUrl(fileName: String): String {
+        return "https://${bucketName}.s3.${regionName}.amazonaws.com/${fileName}"
+    }
+}

--- a/src/main/kotlin/org/grew/grewwebsiteserver/domain/resource/dto/ResourceUploadUrlDto.kt
+++ b/src/main/kotlin/org/grew/grewwebsiteserver/domain/resource/dto/ResourceUploadUrlDto.kt
@@ -1,0 +1,8 @@
+package org.grew.grewwebsiteserver.domain.resource.dto
+
+data class ResourceUploadUrlDto(
+    val fileName: String,
+    val contentType: String,
+    val uploadUrl: String, // 업로드용 URL
+    val downloadUrl: String // 다운로드용 URL
+)

--- a/src/main/kotlin/org/grew/grewwebsiteserver/domain/resource/dto/ResourceUploadUrlRequestDto.kt
+++ b/src/main/kotlin/org/grew/grewwebsiteserver/domain/resource/dto/ResourceUploadUrlRequestDto.kt
@@ -1,0 +1,6 @@
+package org.grew.grewwebsiteserver.domain.resource.dto
+
+data class ResourceUploadUrlRequestDto(
+    val fileName: String,
+    val contentType: String
+)

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -35,3 +35,13 @@ jwt:
     refresh_token_expires_in_sec: 1209600 # 14 days
     header: Authorization
     prefix: Bearer
+
+cloud:
+  aws:
+    credentials:
+      access-key: TEMP_AWS_ACCESS_KEY
+      secret-key: TEMP_AWS_SECRET_KEY
+    region:
+      static: ap-northeast-2  # 예: 서울 리전
+    s3:
+      bucket: grew-website-resource

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,3 +34,15 @@ jwt:
   refresh_token_expires_in_sec: 1209600 # 14 days
   header: Authorization
   prefix: Bearer
+
+
+cloud:
+  aws:
+    credentials:
+      access-key: ${AWS_ACCESS_KEY}
+      secret-key: ${AWS_SECRET_KEY}
+    region:
+      static: ap-northeast-2  # 예: 서울 리전
+    s3:
+      bucket: grew-website-resource
+


### PR DESCRIPTION
## 📝요약

- 파일 업로드를 위한 S3 Presigned URL 발급 API 구현
- 파일 다운로드는 public read 권한으로 버킷을 설정해서 유효기간 없이 접근 가능하도록 설정

## 📋참고 사항

- 당장 큰 문제는 없을 것 같아, 다운로드 url은 public으로 열어놓았어요. 만약 보안상의 이슈로 수정이 필요하다면 클라에 post 전달 할 때마다 새로운 get-only presigned url을 생성해서 전달해야해요.
