### PR TITLE
cors url 주소를 패턴 매칭으로 변경

### DIFF
--- a/src/main/kotlin/org/grew/grewwebsiteserver/config/SecurityConfig.kt
+++ b/src/main/kotlin/org/grew/grewwebsiteserver/config/SecurityConfig.kt
@@ -62,15 +62,15 @@ class SecurityConfig(
 
     @Bean
     fun corsConfigurationSource(): CorsConfigurationSource {
-        val configuration = CorsConfiguration()
-        configuration.allowedOriginPatterns = allowedOriginsPatternRaw.split(",").map { it.trim() }
-        configuration.allowedMethods = listOf("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
-        configuration.allowedHeaders = listOf("*")
-        configuration.allowCredentials = true
-
-        val source = UrlBasedCorsConfigurationSource()
-        source.registerCorsConfiguration("/**", configuration)
-        return source
+        val configuration = CorsConfiguration().apply {
+            allowedOriginPatterns = allowedOriginsPatternRaw.split(",").map { it.trim() }
+            allowedMethods = listOf("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
+            allowedHeaders = listOf("*")
+            allowCredentials = true
+        }
+        return UrlBasedCorsConfigurationSource().apply {
+            registerCorsConfiguration("/**", configuration)
+        }
     }
 
     @Bean

--- a/src/main/kotlin/org/grew/grewwebsiteserver/config/SecurityConfig.kt
+++ b/src/main/kotlin/org/grew/grewwebsiteserver/config/SecurityConfig.kt
@@ -19,8 +19,8 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource
 @EnableMethodSecurity
 class SecurityConfig(
     private val jwtAuthenticationFilter: JwtAuthenticationFilter,
-    @Value("\${cors.allowed-origins}")
-    private val allowedOriginsRaw: String
+    @Value("\${cors.allowed-origins-pattern}")
+    private val allowedOriginsPatternRaw: String
 ) {
 
     @Bean
@@ -63,7 +63,7 @@ class SecurityConfig(
     @Bean
     fun corsConfigurationSource(): CorsConfigurationSource {
         val configuration = CorsConfiguration()
-        configuration.allowedOrigins = allowedOriginsRaw.split(",").map { it.trim() }
+        configuration.allowedOriginPatterns = allowedOriginsPatternRaw.split(",").map { it.trim() }
         configuration.allowedMethods = listOf("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
         configuration.allowedHeaders = listOf("*")
         configuration.allowCredentials = true

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -47,4 +47,4 @@ cloud:
       bucket: grew-website-resource
 
 cors:
-  allowed-origins: http://localhost:3000
+  allowed-origins-pattern: http://localhost:*

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -32,4 +32,4 @@ cloud:
       bucket: grew-website-resource
 
 cors:
-  allowed-origins: ${CORS_ALLOWED_ORIGINS}
+  allowed-origins-pattern: ${CORS_ALLOWED_ORIGINS_PATTERN}


### PR DESCRIPTION
## 📝요약

- cors url 주소를 패턴 매칭으로 변경
- 일일이 주소를 입력하는 번거로움이 있어 `https://*.grew.or.kr` 의 형식으로 해결하고 싶었어요. pattern이라는 기능이 있어서 해당 기능으로 수정합니다.
